### PR TITLE
Fix blank folder creation in s3 bucket

### DIFF
--- a/mkwheelhouse.py
+++ b/mkwheelhouse.py
@@ -73,7 +73,7 @@ class Bucket(object):
     def sync(self, local_dir):
         return subprocess.check_call([
             'aws', 's3', 'sync',
-            local_dir, 's3://{0}/{1}'.format(self.name, self.prefix),
+            local_dir, 's3://{0}{1}'.format(self.name, self.prefix),
             '--region', self.region])
 
     def put(self, body, key):


### PR DESCRIPTION
When mkwheelhouse is configured to sync to a subfolder in a s3 bucket,  `urlparse.path` returns the path with a leading slash. The string formatting in `sync` task creates the URI with two slashes resulting a blank folder being created in the root of the bucket.